### PR TITLE
Rename 'angle' dimension label to 'projection' for Cone3D_Flex data

### DIFF
--- a/Wrappers/Python/cil/framework/acquisition_data.py
+++ b/Wrappers/Python/cil/framework/acquisition_data.py
@@ -125,10 +125,10 @@ class AcquisitionData(DataContainer, Partitioner):
         else:
             return False
 
-    def get_slice(self,channel=None, angle=None, vertical=None, horizontal=None, force=False):
+    def get_slice(self,channel=None, angle=None, vertical=None, horizontal=None, projection=None, force=False): # CHANGES ORDER OF KWARGS BREAKING BACKWARD COMPATIBILITY
         '''Returns a new dataset of a single slice in the requested direction.'''
         try:
-            geometry_new = self.geometry.get_slice(channel=channel, angle=angle, vertical=vertical, horizontal=horizontal)
+            geometry_new = self.geometry.get_slice(channel=channel, angle=angle, vertical=vertical, horizontal=horizontal, projection=projection)
         except ValueError:
             if force:
                 geometry_new = None
@@ -143,13 +143,13 @@ class AcquisitionData(DataContainer, Partitioner):
             centre_slice_pos = (self.geometry.shape[dim]-1) / 2.
             ind0 = int(numpy.floor(centre_slice_pos))
             w2 = centre_slice_pos - ind0
-            out = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=ind0, horizontal=horizontal)
+            out = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=ind0, horizontal=horizontal, projection=projection)
 
             if w2 > 0:
-                out2 = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=ind0 + 1, horizontal=horizontal)
+                out2 = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=ind0 + 1, horizontal=horizontal, projection=projection)
                 out = out * (1 - w2) + out2 * w2
         else:
-            out = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=vertical, horizontal=horizontal)
+            out = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=vertical, horizontal=horizontal, projection=projection)
 
         if len(out.shape) == 1 or geometry_new is None:
             return out

--- a/Wrappers/Python/cil/framework/acquisition_data.py
+++ b/Wrappers/Python/cil/framework/acquisition_data.py
@@ -125,7 +125,7 @@ class AcquisitionData(DataContainer, Partitioner):
         else:
             return False
 
-    def get_slice(self,channel=None, angle=None, vertical=None, horizontal=None, projection=None, force=False): # CHANGES ORDER OF KWARGS BREAKING BACKWARD COMPATIBILITY
+    def get_slice(self,channel=None, angle=None, vertical=None, horizontal=None, projection=None, force=False):
         '''Returns a new dataset of a single slice in the requested direction.'''
         try:
             geometry_new = self.geometry.get_slice(channel=channel, angle=angle, vertical=vertical, horizontal=horizontal, projection=projection)

--- a/Wrappers/Python/cil/framework/acquisition_data.py
+++ b/Wrappers/Python/cil/framework/acquisition_data.py
@@ -17,7 +17,7 @@
 # CIL Developers, listed at: https://github.com/TomographicImaging/CIL/blob/master/NOTICE.txt
 import numpy
 
-from .labels import AcquisitionDimension, Backend
+from .labels import AcquisitionDimension, Backend, AcquisitionType
 from .data_container import DataContainer
 from .partitioner import Partitioner
 
@@ -73,7 +73,6 @@ class AcquisitionData(DataContainer, Partitioner):
 
         if geometry is None:
             raise AttributeError("AcquisitionData requires a geometry")
-        
 
         labels = kwargs.get('dimension_labels', None)
         if labels is not None and labels != geometry.dimension_labels:
@@ -124,11 +123,30 @@ class AcquisitionData(DataContainer, Partitioner):
             return True
         else:
             return False
+        
+    def _get_slice_with_projection(self, channel=None, projection=None, vertical=None, horizontal=None, force=False):
+        '''
+        get_slice for geometries with 'projection' dimension label
+        '''
+        kwargs = {'channel':channel, 'projection':projection, 'vertical':vertical, 'horizontal':horizontal, 'force':force}
+        return self._get_slice(**kwargs)
+        
+    def _get_slice_with_angle(self, channel=None, angle=None, vertical=None, horizontal=None, force=False):
+        '''
+        get_slice for geometries with 'angle' dimension label
+        '''
+        kwargs = {'channel':channel, 'angle':angle, 'vertical':vertical, 'horizontal':horizontal, 'force':force}
+        return self._get_slice(**kwargs)
 
-    def get_slice(self,channel=None, angle=None, vertical=None, horizontal=None, projection=None, force=False):
-        '''Returns a new dataset of a single slice in the requested direction.'''
+
+    def _get_slice(self, **kwargs):
+        '''
+        Functionality of get_slice
+        '''
+
+        force = kwargs.pop('force')
         try:
-            geometry_new = self.geometry.get_slice(channel=channel, angle=angle, vertical=vertical, horizontal=horizontal, projection=projection)
+            geometry_new = self.geometry.get_slice(**kwargs)
         except ValueError:
             if force:
                 geometry_new = None
@@ -137,24 +155,54 @@ class AcquisitionData(DataContainer, Partitioner):
 
         #get new data
         #if vertical = 'centre' slice convert to index and subset, this will interpolate 2 rows to get the center slice value
-        if vertical == 'centre':
+        if kwargs.get('vertical') == 'centre':
             dim = self.geometry.dimension_labels.index('vertical')
 
             centre_slice_pos = (self.geometry.shape[dim]-1) / 2.
             ind0 = int(numpy.floor(centre_slice_pos))
             w2 = centre_slice_pos - ind0
-            out = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=ind0, horizontal=horizontal, projection=projection)
+            kwargs['vertical'] = ind0
+            out = DataContainer.get_slice(self, **kwargs)
 
             if w2 > 0:
-                out2 = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=ind0 + 1, horizontal=horizontal, projection=projection)
+                kwargs['vertical'] = ind0 +  1
+                out2 = DataContainer.get_slice(self, **kwargs)
                 out = out * (1 - w2) + out2 * w2
         else:
-            out = DataContainer.get_slice(self, channel=channel, angle=angle, vertical=vertical, horizontal=horizontal, projection=projection)
+            out = DataContainer.get_slice(self, **kwargs)
 
         if len(out.shape) == 1 or geometry_new is None:
             return out
         else:
             return AcquisitionData(out.array, deep_copy=False, geometry=geometry_new, suppress_warning=True)
+        
+    
+    def get_slice(self, *args, **kwargs):
+        '''
+        Returns a new AcquisitionData of a single slice in the requested direction. Will only return slices where the geometry is reconstructable.
+
+        Parameters
+        ----------
+        channel: int, optional
+            index on channel dimension to slice on. If None, does not slice on this dimension
+        projection or angle: int, optional
+            index on projection or angle dimension to slice on - `projection` is the dimension label used for Cone3D_Flex geometry,`angle` is used for all other geometries.
+            If None, does not slice on this dimension
+        vertical: int, optional
+            index on vertical dimension to slice on. If None, does not slice on this dimension.
+        horizontal: int, optional
+            index on horizontal dimension to slice on. If None, does not slice on this dimension.
+
+        Returns
+        -------
+        AcquisitionData
+            The sliced AcquisitionData
+        '''
+
+        if self.geometry.geom_type & AcquisitionType.CONE_FLEX:
+            return self._get_slice_with_projection(*args, **kwargs)
+        else:
+            return self._get_slice_with_angle(*args, **kwargs)
 
     def reorder(self, order):
         '''

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -1966,6 +1966,12 @@ class AcquisitionGeometry(object):
     @dimension_labels.setter
     def dimension_labels(self, val):
         if val is not None:
+            if self.config.system.geometry & AcquisitionType.CONE_FLEX:
+                if AcquisitionDimension.ANGLE in val:
+                    raise ValueError("Cannot set dimension_labels with AcquisitionDimension.ANGLE for Cone3D_Flex geometry. Use PROJECTION instead.")
+            elif AcquisitionDimension.PROJECTION in val:
+                raise ValueError("Cannot set dimension_labels with AcquisitionDimension.PROJECTION for geometries that use angles. Use ANGLE instead.")
+                
             self._dimension_labels = tuple(map(AcquisitionDimension, val))
 
     @property

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -1944,6 +1944,7 @@ class AcquisitionGeometry(object):
                                 self.config.panel.num_pixels[1],
                                 self.config.panel.num_pixels[0]
                                 ]
+            labels_default = [label if label != AcquisitionDimension.ANGLE else AcquisitionDimension.PROJECTION for label in labels_default]
 
         try:
             labels = self._dimension_labels
@@ -2531,8 +2532,8 @@ class AcquisitionGeometry(object):
                 raise NotImplementedError("Cannot subset Cone3D_Flex geometry by horizontal. Expected horizontal = None. Got horizontal = {0}".format(horizontal))
             if projection is not None:
                 geometry_new.config.system.num_positions = 1
-                geometry_new.config.system.source = [self.config.system.source[angle]]
-                geometry_new.config.system.detector = [self.config.system.detector[angle]]
+                geometry_new.config.system.source = [self.config.system.source[projection]]
+                geometry_new.config.system.detector = [self.config.system.detector[projection]]
             if angle is not None:
                 raise ValueError("Angle dimension does not exist for Cone3D_Flex geometry, perhaps you meant to use 'projection'?")
 

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -1919,7 +1919,7 @@ class AcquisitionGeometry(object):
         # We are using per-projection geometry, not angles
         else:
             shape_dict = {AcquisitionDimension.CHANNEL: self.config.channels.num_channels,
-                        AcquisitionDimension.ANGLE: self.config.system.num_positions,
+                        AcquisitionDimension.PROJECTION: self.config.system.num_positions,
                         AcquisitionDimension.VERTICAL: self.config.panel.num_pixels[1],
                         AcquisitionDimension.HORIZONTAL: self.config.panel.num_pixels[0]}
 
@@ -2199,12 +2199,20 @@ class AcquisitionGeometry(object):
     def set_labels(self, labels=None):
         r'''This method configures the dimension labels of an AcquisitionGeometry object.
 
-        :param labels:  The order of the dimensions describing the data.\
-                        Expects a list containing at least one of the unique labels: 'channel' 'angle' 'vertical' 'horizontal'
-                        default = ['channel','angle','vertical','horizontal']
-        :type labels: list, optional
-        :return: returns a configured AcquisitionGeometry object
-        :rtype: AcquisitionGeometry
+        Parameters
+        ----------
+
+        labels:  list of strings
+            The order of the dimensions describing the data.
+            For most geometries expects a list containing at least one of the unique labels: 'channel' 'angle' 'vertical' 'horizontal'
+            default = ['channel','angle','vertical','horizontal']
+            For Cone3D_Flex geometries expects a list containing at least one of the unique labels: 'channel' 'projection' 'vertical' 'horizontal'
+            default = ['channel', 'projection', 'vertical', 'horizontal']
+
+        Returns
+        --------
+        self: AcquisitionGeometry
+            a configured AcquisitionGeometry object
         '''
         self.dimension_labels = labels
         return self
@@ -2504,7 +2512,7 @@ class AcquisitionGeometry(object):
         return str(self.config)
 
 
-    def get_slice(self, channel=None, angle=None, vertical=None, horizontal=None):
+    def get_slice(self, channel=None, angle=None, vertical=None, horizontal=None, projection=None):
         '''
         Returns a new AcquisitionGeometry of a single slice of in the requested direction. Will only return reconstructable geometries.
         '''
@@ -2521,10 +2529,12 @@ class AcquisitionGeometry(object):
                 raise NotImplementedError("Cannot subset Cone3D_Flex geometry by vertical. Expected vertical = None. Got vertical = {0}".format(vertical))
             if horizontal is not None:
                 raise NotImplementedError("Cannot subset Cone3D_Flex geometry by horizontal. Expected horizontal = None. Got horizontal = {0}".format(horizontal))
-            if angle is not None:
+            if projection is not None:
                 geometry_new.config.system.num_positions = 1
                 geometry_new.config.system.source = [self.config.system.source[angle]]
                 geometry_new.config.system.detector = [self.config.system.detector[angle]]
+            if angle is not None:
+                raise ValueError("Angle dimension does not exist for Cone3D_Flex geometry, perhaps you meant to use 'projection'?")
 
         else:
  
@@ -2539,6 +2549,9 @@ class AcquisitionGeometry(object):
 
             if horizontal is not None:
                 raise ValueError("Cannot calculate system geometry for a horizontal slice")
+
+            if projection is not None:
+                raise ValueError("Projecton dimension does not exist for Cone3D_Flex geometry, perhaps you meant to use 'angle'?")
 
         return geometry_new
 

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -2518,10 +2518,9 @@ class AcquisitionGeometry(object):
     def __str__ (self):
         return str(self.config)
 
-
-    def get_slice(self, channel=None, angle=None, vertical=None, horizontal=None, projection=None):
+    def _get_slice_with_angle(self, channel=None, angle=None, vertical=None, horizontal=None):
         '''
-        Returns a new AcquisitionGeometry of a single slice of in the requested direction. Will only return reconstructable geometries.
+        get_slice for geometry with 'angle' dimension label
         '''
         geometry_new = self.copy()
 
@@ -2530,37 +2529,71 @@ class AcquisitionGeometry(object):
             if hasattr(geometry_new.config.channels,'channel_labels'):
                 geometry_new.config.panel.channel_labels = geometry_new.config.panel.channel_labels[channel]
 
+        if angle is not None:
+            geometry_new.config.angles.angle_data = geometry_new.config.angles.angle_data[angle]
 
-        if geometry_new.geom_type & AcquisitionType.CONE_FLEX:
-            if vertical is not None:
-                raise NotImplementedError("Cannot subset Cone3D_Flex geometry by vertical. Expected vertical = None. Got vertical = {0}".format(vertical))
-            if horizontal is not None:
-                raise NotImplementedError("Cannot subset Cone3D_Flex geometry by horizontal. Expected horizontal = None. Got horizontal = {0}".format(horizontal))
-            if projection is not None:
-                geometry_new.config.system.num_positions = 1
-                geometry_new.config.system.source = [self.config.system.source[projection]]
-                geometry_new.config.system.detector = [self.config.system.detector[projection]]
-            if angle is not None:
-                raise ValueError("Angle dimension does not exist for Cone3D_Flex geometry, perhaps you meant to use 'projection'?")
+        if vertical is not None:
+            if AcquisitionType.PARALLEL & geometry_new.geom_type or vertical == 'centre' or abs(geometry_new.pixel_num_v/2 - vertical) < 1e-6:
+                geometry_new = geometry_new.get_centre_slice()
+            else:
+                raise ValueError("Can only subset centre slice geometry on cone-beam data. Expected vertical = 'centre'. Got vertical = {0}".format(vertical))
 
-        else:
- 
-            if angle is not None:
-                geometry_new.config.angles.angle_data = geometry_new.config.angles.angle_data[angle]
+        if horizontal is not None:
+            raise ValueError("Cannot calculate system geometry for a horizontal slice")
 
-            if vertical is not None:
-                if AcquisitionType.PARALLEL & geometry_new.geom_type or vertical == 'centre' or abs(geometry_new.pixel_num_v/2 - vertical) < 1e-6:
-                    geometry_new = geometry_new.get_centre_slice()
-                else:
-                    raise ValueError("Can only subset centre slice geometry on cone-beam data. Expected vertical = 'centre'. Got vertical = {0}".format(vertical))
-
-            if horizontal is not None:
-                raise ValueError("Cannot calculate system geometry for a horizontal slice")
-
-            if projection is not None:
-                raise ValueError("Projecton dimension does not exist for Cone3D_Flex geometry, perhaps you meant to use 'angle'?")
 
         return geometry_new
+
+    def _get_slice_with_projection(self, channel=None, projection=None, vertical=None, horizontal=None):
+        '''
+        get_slice for geometry with 'projection' dimension label
+        ''' 
+
+        geometry_new = self.copy()
+
+        if channel is not None:
+            geometry_new.config.channels.num_channels = 1
+            if hasattr(geometry_new.config.channels,'channel_labels'):
+                geometry_new.config.panel.channel_labels = geometry_new.config.panel.channel_labels[channel]
+        if projection is not None:
+            geometry_new.config.system.num_positions = 1
+            geometry_new.config.system.source = [self.config.system.source[projection]]
+            geometry_new.config.system.detector = [self.config.system.detector[projection]]
+        if vertical is not None:
+            raise NotImplementedError("Cannot subset Cone3D_Flex geometry by vertical. Expected vertical = None. Got vertical = {0}".format(vertical))
+        if horizontal is not None:
+            raise NotImplementedError("Cannot subset Cone3D_Flex geometry by horizontal. Expected horizontal = None. Got horizontal = {0}".format(horizontal))
+
+        return geometry_new
+
+    def get_slice(self, *args, **kwargs):
+        '''
+        Returns a new AcquisitionGeometry of a single slice in the requested direction. Will only return reconstructable geometries.
+
+        Parameters
+        ----------
+        channel: int, optional
+            index on channel dimension to slice on. If None, does not slice on this dimension
+        projection or angle: int, optional
+            index on projection or angle dimension to slice on - `projection` is the dimension label used for Cone3D_Flex geometry,`angle` is used for all other geometries.
+            If None, does not slice on this dimension
+        vertical: int, optional
+            index on vertical dimension to slice on. If None, does not slice on this dimension.
+        horizontal: int, optional
+            index on horizontal dimension to slice on. If None, does not slice on this dimension.
+
+        Returns
+        -------
+        geometry_new: AcquisitionGeometry
+            The sliced AcquisitionGeometry
+
+        '''
+
+        if self.geom_type & AcquisitionType.CONE_FLEX:
+            return self._get_slice_with_projection(*args, **kwargs)
+        else:
+            return self._get_slice_with_angle(*args, **kwargs)
+        
 
     def allocate(self, value=0, **kwargs):
         '''Allocates an AcquisitionData according to the geometry

--- a/Wrappers/Python/cil/framework/acquisition_geometry.py
+++ b/Wrappers/Python/cil/framework/acquisition_geometry.py
@@ -2209,7 +2209,7 @@ class AcquisitionGeometry(object):
         Parameters
         ----------
 
-        labels:  list of strings
+        labels:  list of strings, optional
             The order of the dimensions describing the data.
             For most geometries expects a list containing at least one of the unique labels: 'channel' 'angle' 'vertical' 'horizontal'
             default = ['channel','angle','vertical','horizontal']

--- a/Wrappers/Python/cil/framework/data_container.py
+++ b/Wrappers/Python/cil/framework/data_container.py
@@ -183,10 +183,12 @@ class DataContainer(object):
 
     def reorder(self, order):
         '''
-        reorders the data in memory as requested.
+        Reorders the data in memory as requested. This is an in-place operation.
 
-        :param order: ordered list of labels from self.dimension_labels
-        :type order: list, sting
+        Parameters
+        ----------
+        order: list or string
+            ordered list of labels from self.dimension_labels
         '''
         try:
             if len(order) != len(self.shape):

--- a/Wrappers/Python/cil/framework/labels.py
+++ b/Wrappers/Python/cil/framework/labels.py
@@ -93,6 +93,8 @@ class _DimensionBase:
         order = cls._default_order(engine)
         if geometry is None:
             return order
+        elif geometry.geom_type & AcquisitionType.CONE_FLEX:
+            order = [label for label in order if label not 'angle' else 'projection']
         return tuple(label for label in order if label in geometry.dimension_labels)
 
     @classmethod
@@ -157,6 +159,7 @@ class AcquisitionDimension(_DimensionBase, StrEnum):
     ANGLE = auto()
     VERTICAL = auto()
     HORIZONTAL = auto()
+    PROJECTION = auto()
 
     @classmethod
     def _default_order(cls, engine: str) -> tuple:

--- a/Wrappers/Python/cil/framework/labels.py
+++ b/Wrappers/Python/cil/framework/labels.py
@@ -98,8 +98,13 @@ class _DimensionBase:
         order = cls._default_order(engine)
         if geometry is None:
             return order
-        elif geometry.geom_type & AcquisitionType.CONE_FLEX:
-            order = [label if label != AcquisitionDimension.ANGLE else AcquisitionDimension.PROJECTION for label in order]
+
+        try:
+            if geometry.geom_type & AcquisitionType.CONE_FLEX:
+                order = [label if label != AcquisitionDimension.ANGLE else AcquisitionDimension.PROJECTION for label in order]
+        except AttributeError:
+            # if geometry is an ImageGeometry, it does not have a geom_type attribute and we also don't need to adjust the labels
+            pass
         return tuple(label for label in order if label in geometry.dimension_labels)
 
     @classmethod

--- a/Wrappers/Python/cil/framework/labels.py
+++ b/Wrappers/Python/cil/framework/labels.py
@@ -21,7 +21,6 @@ try:
 except ImportError: # Python<3.11
     from enum import EnumMeta as EnumType
 
-
 class _StrEnumMeta(EnumType):
     """Python<3.12 requires this in a metaclass (rather than directly in StrEnum)"""
     def __contains__(self, item: str) -> bool:
@@ -89,12 +88,18 @@ class _DimensionBase:
         ----------
         geometry: ImageGeometry | AcquisitionGeometry
             If unspecified, the default order is returned.
+        
+        Notes
+        -----
+        In the case that geometry is None, the default order assumes the geometry is not CONE_FLEX, so includes the label 'angle'.
+        This then needs to be manually replaced with 'projection'.
+
         """
         order = cls._default_order(engine)
         if geometry is None:
             return order
         elif geometry.geom_type & AcquisitionType.CONE_FLEX:
-            order = [label for label in order if label not 'angle' else 'projection']
+            order = [label if label != AcquisitionDimension.ANGLE else AcquisitionDimension.PROJECTION for label in order]
         return tuple(label for label in order if label in geometry.dimension_labels)
 
     @classmethod

--- a/Wrappers/Python/cil/framework/labels.py
+++ b/Wrappers/Python/cil/framework/labels.py
@@ -92,8 +92,8 @@ class _DimensionBase:
         Notes
         -----
         In the case that geometry is None, the default order assumes the geometry is not CONE_FLEX, so includes the label 'angle'.
-        This then needs to be manually replaced with 'projection'.
-
+        If you have CONE_FLEX geometry and geometry=None, the returned order then needs to be manually replaced with 'projection',
+        or instead pass the geometry to this method to get the correct labels.
         """
         order = cls._default_order(engine)
         if geometry is None:

--- a/Wrappers/Python/cil/framework/partitioner.py
+++ b/Wrappers/Python/cil/framework/partitioner.py
@@ -171,7 +171,10 @@ class Partitioner(object):
 
         # copy data
         out = blk_geo.allocate(None)
-        axis = self.dimension_labels.index('angle')
+        try:
+            axis = self.dimension_labels.index('angle')
+        except:
+            axis = self.dimension_labels.index('projection')
 
         for i in range(num_batches):
             out[i].fill(

--- a/Wrappers/Python/cil/framework/partitioner.py
+++ b/Wrappers/Python/cil/framework/partitioner.py
@@ -107,8 +107,7 @@ class Partitioner(object):
 
     def partition(self, num_batches, mode, seed=None):
         '''Partition the data into ``num_batches`` batches using the specified ``mode``.
-
-
+        
         The modes are
 
         1. ``sequential`` - The data will be partitioned into ``num_batches`` batches of sequential indices.
@@ -133,6 +132,10 @@ class Partitioner(object):
         BlockDataContainer
             Block of `AcquisitionData` objects containing the data requested in each batch
 
+        Note
+        ----
+        This only works on datasets with an 'angle' dimension, and is not currently implemented for Cone3D_Flex geometry.
+
         Example
         -------
 
@@ -143,6 +146,11 @@ class Partitioner(object):
         3. [[8, 2, 6], [7, 1], [0, 4], [3, 5]] with ``random_permutation`` and seed 1
 
         '''
+        if 'angle' not in self.dimension_labels:
+            raise NotImplementedError(f"Partitioner only partitions on the `angle` dimension \
+                and therefore can only be used on datasets with an 'angle' dimension. \
+                Dimensions provided: {self.dimension_labels}")
+        
         if mode == Partitioner.SEQUENTIAL:
             return self._partition_deterministic(num_batches, stagger=False)
         elif mode == Partitioner.STAGGERED:
@@ -171,10 +179,7 @@ class Partitioner(object):
 
         # copy data
         out = blk_geo.allocate(None)
-        try:
-            axis = self.dimension_labels.index('angle')
-        except:
-            axis = self.dimension_labels.index('projection')
+        axis = self.dimension_labels.index('angle')
 
         for i in range(num_batches):
             out[i].fill(

--- a/Wrappers/Python/cil/processors/FluxNormaliser.py
+++ b/Wrappers/Python/cil/processors/FluxNormaliser.py
@@ -18,6 +18,7 @@
 
 from cil.framework import Processor, AcquisitionData
 from cil.utilities import multiprocessing as cil_mp
+from cil.framework.labels import AcquisitionType
 
 import numpy
 import logging
@@ -116,6 +117,9 @@ class FluxNormaliser(Processor):
             raise TypeError("Expected AcquistionData, found {}"
                             .format(type(dataset)))
         
+        if dataset.geometry.geom_type & AcquisitionType.CONE_FLEX:
+            raise NotImplementedError("FluxNormaliser does not yet support CONE3D_FLEX data")
+        
         image_axes = 0
         if 'vertical' in dataset.dimension_labels:
             self.v_axis = dataset.get_dimension_axis('vertical')
@@ -208,7 +212,7 @@ class FluxNormaliser(Processor):
         # check flux array is the right size
         flux_size_flat = len(self.flux.ravel())
         if flux_size_flat > 1:
-            data_size_flat = len(dataset.geometry.angles)*dataset.geometry.channels
+            data_size_flat = dataset.num_projections*dataset.geometry.channels
             if data_size_flat != flux_size_flat:
                 raise ValueError("Flux must be a scalar or array with length \
                                     \n = number of projections, found {} and {}"
@@ -323,7 +327,7 @@ class FluxNormaliser(Processor):
                     raise ValueError("Cannot plot ROI for a single angle on 2D data, please specify angle=None to plot ROI on the sinogram")
             
             plt.subplot(212)
-            if len(data.geometry.angles)==1:
+            if data.num_projections==1:
                 plt.plot(0, flux_array, '.r', label='Mean')
                 plt.plot(0, min,'.k', label='Minimum')
                 plt.plot(0, max,'.k', label='Maximum')
@@ -340,7 +344,7 @@ class FluxNormaliser(Processor):
 
             ax1 = plt.gca()
             ax2 = ax1.twiny()
-            valid_ticks = [int(tick) for tick in ax1.get_xticks() if 0 <= tick < len(data.geometry.angles)]
+            valid_ticks = [int(tick) for tick in ax1.get_xticks() if 0 <= tick < data.num_projections]
             ax2.set_xticks(valid_ticks)
             ax2.set_xbound(ax1.get_xbound())
             ax2.set_xticklabels([data.geometry.angles[tick] for tick in valid_ticks])

--- a/Wrappers/Python/cil/processors/FluxNormaliser.py
+++ b/Wrappers/Python/cil/processors/FluxNormaliser.py
@@ -212,7 +212,7 @@ class FluxNormaliser(Processor):
         # check flux array is the right size
         flux_size_flat = len(self.flux.ravel())
         if flux_size_flat > 1:
-            data_size_flat = dataset.num_projections*dataset.geometry.channels
+            data_size_flat = dataset.geometry.num_projections*dataset.geometry.channels
             if data_size_flat != flux_size_flat:
                 raise ValueError("Flux must be a scalar or array with length \
                                     \n = number of projections, found {} and {}"
@@ -327,7 +327,7 @@ class FluxNormaliser(Processor):
                     raise ValueError("Cannot plot ROI for a single angle on 2D data, please specify angle=None to plot ROI on the sinogram")
             
             plt.subplot(212)
-            if data.num_projections==1:
+            if data.geometry.num_projections==1:
                 plt.plot(0, flux_array, '.r', label='Mean')
                 plt.plot(0, min,'.k', label='Minimum')
                 plt.plot(0, max,'.k', label='Maximum')
@@ -344,7 +344,7 @@ class FluxNormaliser(Processor):
 
             ax1 = plt.gca()
             ax2 = ax1.twiny()
-            valid_ticks = [int(tick) for tick in ax1.get_xticks() if 0 <= tick < data.num_projections]
+            valid_ticks = [int(tick) for tick in ax1.get_xticks() if 0 <= tick < data.geometry.num_projections]
             ax2.set_xticks(valid_ticks)
             ax2.set_xbound(ax1.get_xbound())
             ax2.set_xticklabels([data.geometry.angles[tick] for tick in valid_ticks])

--- a/Wrappers/Python/cil/processors/PaganinProcessor.py
+++ b/Wrappers/Python/cil/processors/PaganinProcessor.py
@@ -223,7 +223,7 @@ class PaganinProcessor(Processor):
 
         target_shape = (
             data.get_dimension_size('channel')  if 'channel' in data.dimension_labels else 1,
-            data.get_dimension_size('angle') if 'angle' in data.dimension_labels else 1,
+            data.geometry.num_projections,
             data.get_dimension_size('vertical') if 'vertical' in data.dimension_labels else 1, 
             data.get_dimension_size('horizontal') if 'horizontal' in data.dimension_labels else 1)
             
@@ -247,7 +247,7 @@ class PaganinProcessor(Processor):
         
         # loop over the channels
         for j in range(data.geometry.channels):
-            # loop over the angles
+            # loop over the projections
             for i in tqdm(range(target_shape[1])):
                 padded_buffer[:] = 0
                 padded_buffer[buffer_slice] = data.array[j, i, :, :]

--- a/Wrappers/Python/cil/processors/Slicer.py
+++ b/Wrappers/Python/cil/processors/Slicer.py
@@ -157,9 +157,14 @@ class Slicer(DataProcessor):
         for key in self._roi_input.keys():
             if key not in data.dimension_labels:
                 raise ValueError('Wrong label is specified for roi, expected one of {}.'.format(data.dimension_labels))
-            if key not in ['angle', 'channel']:
-                if isinstance(self._geometry , (AcquisitionGeometry)) and self._geometry.geom_type & AcquisitionType.CONE_FLEX:
-                    raise NotImplementedError("Cone-Flex geometry is not supported by this processor for slicing along any dimension other than 'angles' or 'channels'")
+            if isinstance(self._geometry , (AcquisitionGeometry)):
+                if self._geometry.geom_type & AcquisitionType.CONE_FLEX:
+                    if key not in ['projection', 'channel']:
+                        raise NotImplementedError("Cone-Flex geometry is not supported by this processor for slicing along any dimension other than 'projection' or 'channel'")
+                else:
+                    if key == 'projection':
+                        raise ValueError("'projection' axis does not exist for this geometry, perhaps you meant to use 'angle'?")
+
 
         return True
 
@@ -317,12 +322,13 @@ class Slicer(DataProcessor):
                 geometry_new.set_channels(num_channels=n_elements)
 
             elif axis == 'angle':
-                if self._geometry.geom_type & AcquisitionType.CONE_FLEX:
-                    geometry_new.config.system.num_positions = int(np.ceil((roi.stop - roi.start )/ roi.step))
-                    geometry_new.config.system.source = self._geometry.config.system.source[roi.start:roi.stop:roi.step]
-                    geometry_new.config.system.detector = self._geometry.config.system.detector[roi.start:roi.stop:roi.step]
-                else:
-                    geometry_new.config.angles.angle_data = self._get_angles(roi)
+                geometry_new.config.angles.angle_data = self._get_angles(roi)
+
+            elif axis == 'projection':
+                geometry_new.config.system.num_positions = int(np.ceil((roi.stop - roi.start )/ roi.step))
+                geometry_new.config.system.source = self._geometry.config.system.source[roi.start:roi.stop:roi.step]
+                geometry_new.config.system.detector = self._geometry.config.system.detector[roi.start:roi.stop:roi.step]
+                
 
             elif axis == 'horizontal':
                 pixel_offset = ((self._shape_in[i] -1 - self._pixel_indices[i][1]) - self._pixel_indices[i][0])*0.5

--- a/Wrappers/Python/cil/processors/Slicer.py
+++ b/Wrappers/Python/cil/processors/Slicer.py
@@ -157,13 +157,9 @@ class Slicer(DataProcessor):
         for key in self._roi_input.keys():
             if key not in data.dimension_labels:
                 raise ValueError('Wrong label is specified for roi, expected one of {}.'.format(data.dimension_labels))
-            if isinstance(self._geometry , (AcquisitionGeometry)):
-                if self._geometry.geom_type & AcquisitionType.CONE_FLEX:
-                    if key not in ['projection', 'channel']:
-                        raise NotImplementedError("Cone-Flex geometry is not supported by this processor for slicing along any dimension other than 'projection' or 'channel'")
-                else:
-                    if key == 'projection':
-                        raise ValueError("'projection' axis does not exist for this geometry, perhaps you meant to use 'angle'?")
+            if isinstance(self._geometry , (AcquisitionGeometry)) and self._geometry.geom_type & AcquisitionType.CONE_FLEX \
+                    and key in ['vertical', 'horizontal']:
+                raise NotImplementedError("Cone-Flex geometry is not supported by this processor for slicing along 'vertical' or 'horizontal'")
 
 
         return True

--- a/Wrappers/Python/cil/recon/FBP.py
+++ b/Wrappers/Python/cil/recon/FBP.py
@@ -319,11 +319,18 @@ class GenericFilteredBackProjection(Reconstructor):
         weights_ptr = self._weights.ctypes.data_as(c_float_p)
 
         ag = acquistion_data.geometry
-        if ag.dimension_labels == ('angle','vertical','horizontal'):
+
+        if ag.geom_type & AcquisitionType.CONE_FLEX:
+            projection_label = 'projection'
+        else:
+            projection_label = 'angle'
+
+
+        if ag.dimension_labels == (projection_label,'vertical','horizontal'):
             cilacc.filter_projections_avh(data_ptr, filter_ptr, weights_ptr, self.fft_order, *acquistion_data.shape)
-        elif ag.dimension_labels == ('vertical','angle','horizontal'):
+        elif ag.dimension_labels == ('vertical',projection_label,'horizontal'):
             cilacc.filter_projections_vah(data_ptr, filter_ptr, weights_ptr, self.fft_order, *acquistion_data.shape)
-        elif ag.dimension_labels == ('angle','horizontal'):
+        elif ag.dimension_labels == (projection_label,'horizontal'):
             cilacc.filter_projections_vah(data_ptr, filter_ptr, weights_ptr, self.fft_order, 1, *acquistion_data.shape)
         elif ag.dimension_labels == ('vertical','horizontal'):
             cilacc.filter_projections_avh(data_ptr, filter_ptr, weights_ptr, self.fft_order, 1, *acquistion_data.shape)

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -24,6 +24,7 @@ import re
 import io
 import sys
 from cil.framework import AcquisitionGeometry, ImageGeometry, AcquisitionData, Partitioner, SystemConfiguration
+from cil.framework.labels import AcquisitionDimension
 import warnings
 
 from utils import has_matplotlib
@@ -1788,23 +1789,24 @@ class Test_Cone3D_Flex(unittest.TestCase):
             self.ag.get_centre_slice()
 
     def test_get_slice_angle(self):
-        angle_slice = self.ag.get_slice(angle=1)
-        self.assertEqual(angle_slice.num_projections, 1)
-        self.assertEqual(angle_slice.channels, 4)
-        np.testing.assert_allclose(angle_slice.config.system.source[0].position, np.asarray([0,-1.3,1]))
-        np.testing.assert_allclose(angle_slice.config.system.detector[0].position, np.asarray([0,2,2]))
+        with self.assertRaises(ValueError):
+            self.ag.get_slice(angle=0)
+
+    def test_get_slice_projection(self):
+        projection_slice = self.ag.get_slice(projection=1)
+        self.assertEqual(projection_slice.num_projections, 1)
+        self.assertEqual(projection_slice.channels, 4)
+        np.testing.assert_allclose(projection_slice.config.system.source[0].position, np.asarray([0,-1.3,1]))
+        np.testing.assert_allclose(projection_slice.config.system.detector[0].position, np.asarray([0,2,2]))
         normalised_direction_x = np.asarray([1,0.02,0.0]) / np.linalg.norm(np.asarray([1,0.02,0.0]))
-        np.testing.assert_allclose(angle_slice.config.system.detector[0].direction_x, np.asarray(normalised_direction_x))
-        np.testing.assert_allclose(angle_slice.config.system.detector[0].direction_y, np.asarray([0,0.0,1]))
-        self.assertEqual(len(angle_slice.config.system.source), 1)
+        np.testing.assert_allclose(projection_slice.config.system.detector[0].direction_x, np.asarray(normalised_direction_x))
+        np.testing.assert_allclose(projection_slice.config.system.detector[0].direction_y, np.asarray([0,0.0,1]))
+        self.assertEqual(len(projection_slice.config.system.source), 1)
 
     def test_get_slice_channel(self):
         channel_slice = self.ag.get_slice(channel=1)
         self.assertEqual(channel_slice.num_projections, 2)
         self.assertEqual(channel_slice.channels, 1)
-        print(channel_slice.config.system.source[0].position, [0,-1,0])
-        print(type(channel_slice.config.system.source[0].position))
-
         np.testing.assert_allclose(channel_slice.config.system.source[0].position, np.asarray([0,-1,0]))
         np.testing.assert_allclose(channel_slice.config.system.detector[0].position, np.asarray([0,2,1]))
         np.testing.assert_allclose(channel_slice.config.system.detector[0].direction_x, np.asarray([1,0.0, 0.0]))
@@ -1823,6 +1825,11 @@ class Test_Cone3D_Flex(unittest.TestCase):
         with self.assertWarns(UserWarning):
             a = self.ag.set_angles([0, 1])
             self.assertTrue(a==self.ag)
+
+    def test_default_labels(self):
+        expected_labels=[AcquisitionDimension.CHANNEL, AcquisitionDimension.PROJECTION, AcquisitionDimension.VERTICAL, AcquisitionDimension.HORIZONTAL]
+        for x,y in zip(expected_labels, self.ag.dimension_labels):
+            self.assertEqual(x,y)
 
 
 class TestSubset(unittest.TestCase):

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -1632,6 +1632,19 @@ class Test_Cone3D(unittest.TestCase):
         AG.config.system.set_centre_of_rotation(*gold)
         out = AG.config.system.calculate_centre_of_rotation()
         np.testing.assert_allclose(out, gold, err_msg="Failed tilted detector x B")
+    
+    def test_set_dimension_labels(self):
+        AG = AcquisitionGeometry.create_Cone3D(source_position=[0,-500,0], detector_position=[0.,1000.,0]).set_angles([0,1]).set_panel(num_pixels=[10, 20]).set_channels(4)
+        unexpected_labels=[AcquisitionDimension.CHANNEL, AcquisitionDimension.PROJECTION, AcquisitionDimension.VERTICAL, AcquisitionDimension.HORIZONTAL]
+
+        with self.assertRaises(ValueError):
+            AG.dimension_labels = unexpected_labels
+        
+        acceptable_labels = [AcquisitionDimension.ANGLE, AcquisitionDimension.CHANNEL,AcquisitionDimension.VERTICAL, AcquisitionDimension.HORIZONTAL]
+
+        AG.dimension_labels = acceptable_labels
+
+        self.assertEqual(list(AG.dimension_labels), acceptable_labels)
 
 class Test_Cone3D_Flex(unittest.TestCase):
 
@@ -1830,6 +1843,18 @@ class Test_Cone3D_Flex(unittest.TestCase):
         expected_labels=[AcquisitionDimension.CHANNEL, AcquisitionDimension.PROJECTION, AcquisitionDimension.VERTICAL, AcquisitionDimension.HORIZONTAL]
         for x,y in zip(expected_labels, self.ag.dimension_labels):
             self.assertEqual(x,y)
+
+    def test_set_dimension_labels(self):
+        unexpected_labels=[AcquisitionDimension.CHANNEL, AcquisitionDimension.ANGLE, AcquisitionDimension.VERTICAL, AcquisitionDimension.HORIZONTAL]
+
+        with self.assertRaises(ValueError):
+            self.ag.dimension_labels = unexpected_labels
+        
+        acceptable_labels = [AcquisitionDimension.PROJECTION, AcquisitionDimension.CHANNEL,AcquisitionDimension.VERTICAL, AcquisitionDimension.HORIZONTAL]
+
+        self.ag.dimension_labels = acceptable_labels
+
+        self.assertEqual(list(self.ag.dimension_labels), acceptable_labels)
 
 
 class TestSubset(unittest.TestCase):

--- a/Wrappers/Python/test/test_AcquisitionGeometry.py
+++ b/Wrappers/Python/test/test_AcquisitionGeometry.py
@@ -1802,7 +1802,7 @@ class Test_Cone3D_Flex(unittest.TestCase):
             self.ag.get_centre_slice()
 
     def test_get_slice_angle(self):
-        with self.assertRaises(ValueError):
+        with self.assertRaises(TypeError):
             self.ag.get_slice(angle=0)
 
     def test_get_slice_projection(self):
@@ -1825,6 +1825,17 @@ class Test_Cone3D_Flex(unittest.TestCase):
         np.testing.assert_allclose(channel_slice.config.system.detector[0].direction_x, np.asarray([1,0.0, 0.0]))
         np.testing.assert_allclose(channel_slice.config.system.detector[0].direction_y, np.asarray([0.,0.,1]))
         self.assertEqual(len(channel_slice.config.system.source), 2)
+
+        channel_slice = self.ag.get_slice(1)
+        self.assertEqual(channel_slice.num_projections, 2)
+        self.assertEqual(channel_slice.channels, 1)
+        np.testing.assert_allclose(channel_slice.config.system.source[0].position, np.asarray([0,-1,0]))
+        np.testing.assert_allclose(channel_slice.config.system.detector[0].position, np.asarray([0,2,1]))
+        np.testing.assert_allclose(channel_slice.config.system.detector[0].direction_x, np.asarray([1,0.0, 0.0]))
+        np.testing.assert_allclose(channel_slice.config.system.detector[0].direction_y, np.asarray([0.,0.,1]))
+        self.assertEqual(len(channel_slice.config.system.source), 2)
+
+
 
     def test_get_slice_vertical(self):
         with self.assertRaises(NotImplementedError):

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -807,7 +807,13 @@ class TestDataContainer(CCPiTestClass):
         ag_flex = AcquisitionGeometry.create_Cone3D_Flex(source_position_set, detector_position_set, detector_direction_x_set, detector_direction_y_set).set_panel([128,64],[0.1,0.2]).set_channels(4)
         ad_flex = ag_flex.allocate()
 
-        ad_flex.reorder(new_order)
+
+        # check it fails if we try to use a list containing 'ANGLE':
+        with self.assertRaises(ValueError):
+            ad_flex.reorder(new_order)
+
+        new_order[3] = AcquisitionDimension["PROJECTION"]
+
         self.assertListEqual(new_order, list(ad_flex.dimension_labels))
 
         ss3 = ad_flex.get_slice(angle=0)
@@ -816,7 +822,7 @@ class TestDataContainer(CCPiTestClass):
 
         ss4 = ad_flex.get_slice(channel=0)
         self.assertListEqual([AcquisitionDimension["HORIZONTAL"] ,
-                    AcquisitionDimension["VERTICAL"], AcquisitionDimension["ANGLE"]], list(ss4.geometry.dimension_labels))
+                    AcquisitionDimension["VERTICAL"], AcquisitionDimension["PROJECTION"]], list(ss4.geometry.dimension_labels))
 
 
     def test_ImageDataSubset(self):

--- a/Wrappers/Python/test/test_DataContainer.py
+++ b/Wrappers/Python/test/test_DataContainer.py
@@ -778,10 +778,11 @@ class TestDataContainer(CCPiTestClass):
 
         # expected dimension_labels
 
-        self.assertListEqual([AcquisitionDimension["CHANNEL"] ,
+        default_order = [AcquisitionDimension["CHANNEL"] ,
                  AcquisitionDimension["ANGLE"] , AcquisitionDimension["VERTICAL"] ,
-                 AcquisitionDimension["HORIZONTAL"]],
-                              list(sgeometry.dimension_labels))
+                 AcquisitionDimension["HORIZONTAL"]]
+
+        self.assertListEqual(default_order, list(sgeometry.dimension_labels))
         sino = sgeometry.allocate()
 
         # test reshape
@@ -812,17 +813,18 @@ class TestDataContainer(CCPiTestClass):
         with self.assertRaises(ValueError):
             ad_flex.reorder(new_order)
 
-        new_order[3] = AcquisitionDimension["PROJECTION"]
+        # By default, flex geometry has 'projection' label instead of 'angle'
+        default_order[1] = AcquisitionDimension["PROJECTION"]
 
-        self.assertListEqual(new_order, list(ad_flex.dimension_labels))
+        print("FLEX DIMS: ", ad_flex.dimension_labels)
 
-        ss3 = ad_flex.get_slice(angle=0)
-        self.assertListEqual([AcquisitionDimension["HORIZONTAL"] ,
-                 AcquisitionDimension["CHANNEL"] , AcquisitionDimension["VERTICAL"]], list(ss3.geometry.dimension_labels))
+        self.assertListEqual(default_order, list(ad_flex.dimension_labels))
+
+        ss3 = ad_flex.get_slice(projection=0)
+        self.assertListEqual([AcquisitionDimension["CHANNEL"] , AcquisitionDimension["VERTICAL"], AcquisitionDimension["HORIZONTAL"]], list(ss3.geometry.dimension_labels))
 
         ss4 = ad_flex.get_slice(channel=0)
-        self.assertListEqual([AcquisitionDimension["HORIZONTAL"] ,
-                    AcquisitionDimension["VERTICAL"], AcquisitionDimension["PROJECTION"]], list(ss4.geometry.dimension_labels))
+        self.assertListEqual([AcquisitionDimension["PROJECTION"], AcquisitionDimension["VERTICAL"], AcquisitionDimension["HORIZONTAL"]], list(ss4.geometry.dimension_labels))
 
 
     def test_ImageDataSubset(self):

--- a/Wrappers/Python/test/test_DataProcessor.py
+++ b/Wrappers/Python/test/test_DataProcessor.py
@@ -1088,7 +1088,7 @@ class TestSlicer(unittest.TestCase):
             proc = Slicer(roi=roi_invalid)
             proc.set_input(ag)
         
-        roi_valid =  {'angle':(1,3,2)}
+        roi_valid =  {'projection':(1,3,2)}
 
         slicer = Slicer(roi=roi_valid)
         sliced = slicer(ag)
@@ -3274,6 +3274,13 @@ class TestFluxNormaliser(unittest.TestCase):
                         [[7,8,9],[7,8,9],[7,8,9]]])
         self.data_simple = AcquisitionData(arr, geometry=ag)
 
+        source_position_set=[[0,-100000,0]]*3
+        detector_position_set=[[0,0,0]]*3
+        detector_direction_x_set=[[1, 0, 0]]*3
+        detector_direction_y_set=[[0, 0, 1]]*3
+        cone_flex_ag = AcquisitionGeometry.create_Cone3D_Flex(source_position_set, detector_position_set, detector_direction_x_set, detector_direction_y_set).set_panel([3,3])
+        self.cone_flex  = AcquisitionData(arr, geometry=cone_flex_ag)
+
     def error_message(self,processor, test_parameter):
             return "Failed with processor " + str(processor) + " on test parameter " + test_parameter
 
@@ -3298,6 +3305,11 @@ class TestFluxNormaliser(unittest.TestCase):
         processor = FluxNormaliser()
         with self.assertRaises(ValueError):
             processor.check_input(self.data_cone)
+
+        # check there's a not implemented error if cone flex geom is used:
+        processor = FluxNormaliser(flux=[1,2,3])
+        with self.assertRaises(NotImplementedError):
+            processor.check_input(self.cone_flex)
 
     def test_calculate_flux(self):
         # check there is an error if flux array size is not equal to the number of angles in data

--- a/Wrappers/Python/test/test_PluginsAstra_Geometry.py
+++ b/Wrappers/Python/test/test_PluginsAstra_Geometry.py
@@ -452,7 +452,7 @@ class TestGeometry_Cone3D(unittest.TestCase):
                                                          detector_position_set=detector_position_set,\
                                                          detector_direction_x_set=detector_direction_x_set,\
                                                          detector_direction_y_set=detector_direction_y_set)\
-                                      .set_labels(['vertical', 'angle','horizontal'])\
+                                      .set_labels(['vertical', 'projection','horizontal'])\
                                       .set_panel((pixels_x,pixels_y), (0.1,0.2))
         
 
@@ -643,7 +643,7 @@ class TestGeometry_Cone3D_Flex(unittest.TestCase):
                                                          detector_position_set=self.detector_position_set,\
                                                          detector_direction_x_set=self.detector_direction_x_set,\
                                                          detector_direction_y_set=self.detector_direction_y_set) \
-                                      .set_labels(['vertical', 'angle','horizontal'])\
+                                      .set_labels(['vertical', 'projection','horizontal'])\
                                       .set_panel((self.pixels_x, self.pixels_y), (0.1,0.2))
         
         self.ig = create_cone_flex_default_ig(self.ag)

--- a/Wrappers/Python/test/test_reconstructors.py
+++ b/Wrappers/Python/test/test_reconstructors.py
@@ -83,6 +83,8 @@ class Test_Reconstructor(unittest.TestCase):
         self.ad3D = self.ag3D.allocate('random', seed=3)
         self.ig3D = self.ag3D.get_ImageGeometry()
 
+        self.ad2D = self.ag.allocate('random', seed=3)
+
     @unittest.skipUnless(has_tigre, "TIGRE not installed")
     def test_defaults(self):
         reconstructor = Reconstructor(self.ad3D)

--- a/Wrappers/Python/test/test_subset.py
+++ b/Wrappers/Python/test/test_subset.py
@@ -200,10 +200,10 @@ class Test_get_slice(unittest.TestCase):
                                                     detector_position_set=detector_position_set, \
                                                     detector_direction_x_set=detector_direction_x_set, \
                                                     detector_direction_y_set=detector_direction_y_set)\
-                                     .set_panel(num_pixels=[5,4]).set_channels(6).set_labels(['channel','angle','vertical','horizontal'])
+                                     .set_panel(num_pixels=[5,4]).set_channels(6).set_labels(['channel','projection','vertical','horizontal'])
 
         data = ag.allocate('random')
-        data_new = data.get_slice(angle=1)
+        data_new = data.get_slice(projection=1)
         self.assertEqual(data_new.shape,(6, 4, 5))
         self.assertEqual(data_new.geometry.dimension_labels,('channel','vertical','horizontal'))
 
@@ -387,7 +387,6 @@ class TestSubset(unittest.TestCase):
         sub = data.get_slice(angle = sliceme)
         self.assertTrue( sub.geometry.angles[0] == data.geometry.angles[sliceme])
     def test_AcquisitionDataSubset1f(self):
-
         data = self.ag.allocate()
         #self.assertTrue( data.shape == (4,20,2,3))
         sliceme = 1
@@ -395,27 +394,23 @@ class TestSubset(unittest.TestCase):
         self.assertTrue( sub.geometry.angles[0] == data.geometry.angles[sliceme])
 
     def test_AcquisitionDataSubset1g(self):
-
         data = self.ag_cone.allocate()
         sliceme = 1
         sub = data.get_slice(angle = sliceme)
         self.assertTrue( sub.geometry.angles[0] == data.geometry.angles[sliceme])
 
     def test_AcquisitionDataSubset1h(self):
-
         data = self.ag_cone.allocate()
         sub = data.get_slice(vertical = 'centre')
         self.assertTrue( sub.geometry.shape == (4,3,20))
 
     def test_AcquisitionDataSubset1i(self):
-
         data = self.ag_cone.allocate()
         sliceme = 1
         sub = data.get_slice(vertical = sliceme, force=True)
         self.assertTrue( sub.shape == (4, 3, 20))
 
     def test_AcquisitionDataSubset1j(self):
-
         data = self.ag.allocate()
         sub = data.get_slice(angle = 0)
         sub = sub.get_slice(vertical = 0)
@@ -425,14 +420,12 @@ class TestSubset(unittest.TestCase):
 
     def test_AcquisitionDataSubset1k(self):
         data = self.ag_flex.allocate()
-        sub = data.get_slice(angle=0)
-        print(sub.shape, sub.dimension_labels)
+        sub = data.get_slice(projection=0)
         self.assertTrue( sub.geometry.shape == (4, 2, 20))
 
 
     def test_AcquisitionDataSubset1l(self):
         data = self.ag_flex.allocate()
-        sub = data.get_slice(angle = 0)
+        sub = data.get_slice(projection = 0)
         sub = sub.get_slice(channel = 0)
-        print(sub.shape, sub.dimension_labels)
         self.assertTrue(sub.shape == (2, 20))

--- a/Wrappers/Python/test/utils_projectors.py
+++ b/Wrappers/Python/test/utils_projectors.py
@@ -156,7 +156,10 @@ class SimData(object):
 
         ag_new = AcquisitionGeometry.create_Cone3D_Flex(src_pos_set, det_pos_set, det_dir_x_set, det_dir_y_set)
         ag_new.set_panel([self.acq_data.geometry.pixel_num_h, self.acq_data.geometry.pixel_num_v], [self.acq_data.geometry.pixel_size_h, self.acq_data.geometry.pixel_size_v], origin='bottom-left')
-        ag_new.set_labels(self.acq_data.dimension_labels)
+        # Flex geometry has the same labels except uses PROJECTION instead of ANGLE:
+        new_labels = list(self.acq_data.dimension_labels)
+        new_labels[1] = AcquisitionDimension.PROJECTION
+        ag_new.set_labels(new_labels)
 
         self.ag = ag_new
         self._get_roi_3D()


### PR DESCRIPTION
## Describe your changes

Only allow CONE_FLEX geometry to use new 'projection' dim label. Other geom types can't use it.
CONE_FLEX geom can't use 'angle' dim label.

Before carrying out the changes I made a list of where CIL would be impacted:

 
To begin with we will allow flex to use 'projections' not other types - they have to use angles
 
 
 
Framework
 
1.	Labels

- get_order_for_engine()  - If flex geometry replace all angles with projections

2.	AcquisitionGeometry
•	Alter shape property for cone flex
•	get_slice should use projection instead of angle for cone3Dflex
•	Not sure where we throw an error if they set angle as a label instead of projection? Do we do it in set_labels? And check for cone 3D flex

3.	Partitioner
•	Looks like currently doesn't work for flex geometry - so this is an issue to be solved in the main PR, not here. 
 
Display
 
1.	Show2D Does have special behaviour for angles but I think this can be left in

 
Processors: Any processors not mentioned here are not implemented for cone geom or not relevant:
 
1.	FluxNormaliser

- Lots of use of angle throughout so would be significant update
- Uses angles list to determine size - can replace with number of projections
- For display etc. refers to angle a lot, could refer to as projection for flex data
-Decided out of scope for this PR, made not implemented instead.

2.	Paganin
Angle used for sizing so can optionally use projection instead

3.	Slicer
Allow flex to slice on projections  not angles

 
Reconstruction
1.	Recon
When checking order of labels, allow 'projections' instead of angles




## Describe any testing you have performed
*Please add any demo scripts to [CIL-Demos/misc/](https://github.com/TomographicImaging/CIL-Demos/tree/main/misc)*


## Link relevant issues


## Checklist when you are ready to request a review

- [x] I have performed a self-review of my code
- [x] I have added docstrings in line with the guidance in the developer guide
- [x] I have implemented unit tests that cover any new or modified functionality
- [ ] CHANGELOG.md has been updated with any functionality change
- [ ] Request review from all relevant developers
- [ ] Change pull request label to 'Waiting for review' 

## Contribution Notes

Please read and adhere to the [developer guide](https://tomographicimaging.github.io/CIL/nightly/developer_guide.html) and local patterns and conventions.
 - [x] The content of this Pull Request (the Contribution) is intentionally submitted for inclusion in CIL (the Work) under the terms and conditions of the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0) License.
 - [x] I confirm that the contribution does not violate any intellectual property rights of third parties
